### PR TITLE
Change description of rebase and cherry-pick

### DIFF
--- a/_sources/git/confusion.rst.txt
+++ b/_sources/git/confusion.rst.txt
@@ -41,7 +41,7 @@ Github/Gitlab/et al. make this server-side cloning easy with a GUI button that
 says "fork."  After forking on Github, then one does a ``git clone`` to get a
 local working copy of the repository to code in.
 
-merge vs. rebase vs. cherrypick
+merge vs. rebase vs. cherry-pick
 ================================
 
 This is really a fundamental issue to the way that git is storing history
@@ -55,14 +55,14 @@ quickref nature of this page, here is the generalization:
 * ``git rebase`` redefines the parent of a chosen commit. This has many uses, but
   when used in place of ``git merge``, one can move commits to another branch as if
   they had originally been started there.
-* ``git cherrypick`` can now handle multiple commits, so its function can be
-  similar to ``git rebase``. However, one key distinction is that the commits being
-  moved are left in their original place with git cherrypick, whereas with
-  ``git rebase``, they only exist at the destination after the operation.
+* ``git cherry-pick`` can now handle multiple commits, so its function
+  can be similar to ``git -rebase``. However, one key distinction is
+  that ``git rebase`` also moves the branch head, which ``git
+  cherry-pick`` doesn't do.
 
 Another point of potential confusion: what exactly is meant by "moving commits"
 or "applying commits" or "replaying commits" as you will often see in the
-explanations of ``git rebase`` and ``git cherrypick``. This sounds suspiciously like
+explanations of ``git rebase`` and ``git cherry-pick``. This sounds suspiciously like
 git is applying deltas, but we know that commits are snapshots. In fact, git is
 calculating diffs between adjacent commits, and applying those as patches to
 the new commits. So in this case, it is using deltas to perform the requested

--- a/_sources/git/git-philosophy.rst.txt
+++ b/_sources/git/git-philosophy.rst.txt
@@ -23,7 +23,7 @@ repository, git needs the information from that commit, whereas SVN needs the
 information for that commit and the entire history leading to it.
 
 Even in the case of git operations that use diffs
-(e.g. `git cherrypick`, `git rebase`, etc.), git finds the relevant snapshots
+(e.g. `git cherry-pick`, `git rebase`, etc.), git finds the relevant snapshots
 and calculates the deltas on the fly.
 
 ## 2) "History is only for humans"

--- a/_sources/git/git_philosophy.rst.txt
+++ b/_sources/git/git_philosophy.rst.txt
@@ -23,7 +23,7 @@ repository, git needs the information from that commit, whereas SVN needs the
 information for that commit and the entire history leading to it.
 
 Even in the case of git operations that use diffs
-(e.g. ``git cherrypick``, ``git rebase``, etc.), git finds the relevant snapshots
+(e.g. ``git cherry-pick``, ``git rebase``, etc.), git finds the relevant snapshots
 and calculates the deltas on the fly.
 
 2) "History is only for humans"

--- a/_sources/git/git_workflows.rst.txt
+++ b/_sources/git/git_workflows.rst.txt
@@ -60,7 +60,7 @@ original post, ["A successful Git branching
 model,"](http://nvie.com/posts/a-successful-git-branching-model/) is well worth
 a read.
 
-At the backbone of the project are the **maste**r and the **develop** branches.
+At the backbone of the project are the **master** and the **develop** branches.
 Supporting branches are all **features**, **releases**, and **hotfixes**. The
 figure and table below summarize how all of these branches work together.
 

--- a/_sources/git/git_workflows.rst.txt
+++ b/_sources/git/git_workflows.rst.txt
@@ -13,7 +13,7 @@ Summary:
 Most of this section comes from the `Atlassian workflow overview
 <https://www.atlassian.com/git/tutorials/comparing-workflows/>`_, including the
 figures (under the `CC-au license
-<https://creativecommons.org/licenses/by/2.5/au/)>`_. I like this presentation
+<https://creativecommons.org/licenses/by/2.5/au/>`_). I like this presentation
 of git workflows, because it starts from the SVN-like model that many are
 comfortable with, and adds one new concept for each successive workflow. This
 way, one can partition their understanding and choose the level at which they

--- a/_sources/git/resources.rst.txt
+++ b/_sources/git/resources.rst.txt
@@ -6,43 +6,43 @@ Big list o' resources -- links to external sites
 general reference, tutorials, cheatsheets
 ==========================================
 
-pro git book (https://git-scm.com/book/en/v2)
+`pro git book <https://git-scm.com/book/en/v2>`_
 
-| atlassian git and related tools tutorials (https://www.atlassian.com/git/tutorials)
-| github guides (https://guides.github.com)
-| github list of external tutorials (https://help.github.com/articles/good-resources-for-learning-git-and-github/)
+| `atlassian git and related tools tutorials <https://www.atlassian.com/git/tutorials>`_
+| `github guides <https://guides.github.com>`_
+| `github list of external tutorials <https://help.github.com/articles/good-resources-for-learning-git-and-github/>`_
 
-| git quick/basic reference (http://gitref.org/index.html)
-| github git cheatsheet (https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf)
-| atlassian git cheatsheet (https://www.atlassian.com/dms/wac/images/landing/git/atlassian_git_cheatsheet.pdf)
+| `git quick/basic reference <http://gitref.org/index.html>`_
+| `github git cheatsheet <https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf>`_
+| `atlassian git cheatsheet <https://www.atlassian.com/dms/wac/images/landing/git/atlassian_git_cheatsheet.pdf>`_
 
 branching, forking, remotes
 ============================
-| learn git branching - in-depth tutorial (http://pcottle.github.io/learnGitBranching)
-| the first page of the reference chapter on git branching (https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell)
-| syncing (remote, fetch, pull, push) overview (https://www.atlassian.com/git/tutorials/syncing)
+| `learn git branching - in-depth tutorial <http://pcottle.github.io/learnGitBranching>`_
+| `the first page of the reference chapter on git branching <https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell>`_
+| `syncing (remote, fetch, pull, push) overview <https://www.atlassian.com/git/tutorials/syncing>`_
 | https://help.github.com/articles/fork-a-repo/
 | https://help.github.com/articles/syncing-a-fork/
 
 best practices
 ===============
-| 10 simple rules paper (http://biorxiv.org/content/early/2016/05/13/048744)
-| Commit Often, Perfect Later, Publish Once: Git Best Practices (http://sethrobertson.github.io/GitBestPractices/)
-| A Quick Introduction to Version Control with Git and Github (http://dx.doi.org/10.1371/journal.pcbi.1004668)
-| No Foxtrot Merges Allowed (http://bit-booster.blogspot.ca/2016/02/no-foxtrots-allowed.html)
-| Sympy syncing guidance (prefer merge over rebase) (https://github.com/sympy/sympy/wiki/Development-workflow#synchronization-with-master-sympy-sympy)
-| Getting Solid at Git rebase vs. merge (https://medium.com/@porteneuve/getting-solid-at-git-rebase-vs-merge-4fa1a48c53aa)
+| `10 simple rules paper <http://biorxiv.org/content/early/2016/05/13/048744>`_
+| `Commit Often, Perfect Later, Publish Once: Git Best Practices <http://sethrobertson.github.io/GitBestPractices/>`_
+| `A Quick Introduction to Version Control with Git and Github <http://dx.doi.org/10.1371/journal.pcbi.1004668>`_
+| `No Foxtrot Merges Allowed <http://bit-booster.blogspot.ca/2016/02/no-foxtrots-allowed.html>`_
+| `Sympy syncing guidance <prefer merge over rebase>`_ (https://github.com/sympy/sympy/wiki/Development-workflow#synchronization-with-master-sympy-sympy)
+| `Getting Solid at Git rebase vs. merge <https://medium.com/@porteneuve/getting-solid-at-git-rebase-vs-merge-4fa1a48c53aa>`_
 
 workflows and history cleaning for PRs
 =======================================
-| workflows overview  (https://www.atlassian.com/git/tutorials/comparing-workflows)
-| the original gitflow  (http://nvie.com/posts/a-successful-git-branching-model/)
-| gitflow best practices and variations discussion  (http://stackoverflow.com/questions/24582319/branching-and-merging-best-practices-in-git)
-| git workflow guide with examples for pros (simple models)  (https://www.toptal.com/git/git-workflows-for-pros-a-good-git-guide)
-| git workflows that work  (http://blog.endpoint.com/2014/05/git-workflows-that-work.html)
+| `workflows overview  <https://www.atlassian.com/git/tutorials/comparing-workflows>`_
+| `the original gitflow  <http://nvie.com/posts/a-successful-git-branching-model/>`_
+| `gitflow best practices and variations discussion  <http://stackoverflow.com/questions/24582319/branching-and-merging-best-practices-in-git>`_
+| `git workflow guide with examples for pros <simple models>`_  (https://www.toptal.com/git/git-workflows-for-pros-a-good-git-guide)
+| `git workflows that work  <http://blog.endpoint.com/2014/05/git-workflows-that-work.html>`_
 
-| getting solid at git rebase vs. merge (https://medium.com/@porteneuve/getting-solid-at-git-rebase-vs-merge-4fa1a48c53aa#.wozxfe8am)
-| git ways of rewriting history (https://robots.thoughtbot.com/git-interactive-rebase-squash-amend-rewriting-history)
+| `getting solid at git rebase vs. merge <https://medium.com/@porteneuve/getting-solid-at-git-rebase-vs-merge-4fa1a48c53aa#.wozxfe8am>`_
+| `git ways of rewriting history <https://robots.thoughtbot.com/git-interactive-rebase-squash-amend-rewriting-history>`_
 
 If you want to experiment with the Gitflow model, This script
 (`gitflow_history.sh </uploads/3ffd72450352f16d96ec6d4eeeff6a20/gitflow_history.sh>`_)
@@ -51,5 +51,5 @@ empty directory.
 
 miscellaneous non-git resources
 ===============================
-| make code citable (https://guides.github.com/activities/citable-codehttps://guides.github.com/activities/citable-code/)
-| semantic versioning (http://semver.org/)
+| `make code citable <https://guides.github.com/activities/citable-codehttps://guides.github.com/activities/citable-code/>`_
+| `semantic versioning <http://semver.org/>`_

--- a/_sources/git/resources.rst.txt
+++ b/_sources/git/resources.rst.txt
@@ -45,7 +45,7 @@ workflows and history cleaning for PRs
 | git ways of rewriting history (https://robots.thoughtbot.com/git-interactive-rebase-squash-amend-rewriting-history)
 
 If you want to experiment with the Gitflow model, This script
-([gitflow_history.sh](/uploads/3ffd72450352f16d96ec6d4eeeff6a20/gitflow_history.sh))
+(`gitflow_history.sh </uploads/3ffd72450352f16d96ec6d4eeeff6a20/gitflow_history.sh>`_)
 will generate the history shown in the Gitflow figure above; just execute in an
 empty directory.
 

--- a/_sources/git/resources.rst.txt
+++ b/_sources/git/resources.rst.txt
@@ -51,5 +51,5 @@ empty directory.
 
 miscellaneous non-git resources
 ===============================
-| `make code citable <https://guides.github.com/activities/citable-codehttps://guides.github.com/activities/citable-code/>`_
+| `make code citable <https://guides.github.com/activities/citable-code/>`_
 | `semantic versioning <http://semver.org/>`_

--- a/html/_sources/git/confusion.rst.txt
+++ b/html/_sources/git/confusion.rst.txt
@@ -41,7 +41,7 @@ Github/Gitlab/et al. make this server-side cloning easy with a GUI button that
 says "fork."  After forking on Github, then one does a ``git clone`` to get a
 local working copy of the repository to code in.
 
-merge vs. rebase vs. cherrypick
+merge vs. rebase vs. cherry-pick
 ================================
 
 This is really a fundamental issue to the way that git is storing history
@@ -55,14 +55,14 @@ quickref nature of this page, here is the generalization:
 * ``git rebase`` redefines the parent of a chosen commit. This has many uses, but
   when used in place of ``git merge``, one can move commits to another branch as if
   they had originally been started there.
-* ``git cherrypick`` can now handle multiple commits, so its function can be
-  similar to ``git rebase``. However, one key distinction is that the commits being
-  moved are left in their original place with git cherrypick, whereas with
-  ``git rebase``, they only exist at the destination after the operation.
+* ``git cherry-pick`` can now handle multiple commits, so its function
+  can be similar to ``git -rebase``. However, one key distinction is
+  that ``git rebase`` also moves the branch head, which ``git
+  cherry-pick`` doesn't do.
 
 Another point of potential confusion: what exactly is meant by "moving commits"
 or "applying commits" or "replaying commits" as you will often see in the
-explanations of ``git rebase`` and ``git cherrypick``. This sounds suspiciously like
+explanations of ``git rebase`` and ``git cherry-pick``. This sounds suspiciously like
 git is applying deltas, but we know that commits are snapshots. In fact, git is
 calculating diffs between adjacent commits, and applying those as patches to
 the new commits. So in this case, it is using deltas to perform the requested

--- a/html/_sources/git/git_philosophy.rst.txt
+++ b/html/_sources/git/git_philosophy.rst.txt
@@ -23,7 +23,7 @@ repository, git needs the information from that commit, whereas SVN needs the
 information for that commit and the entire history leading to it.
 
 Even in the case of git operations that use diffs
-(e.g. ``git cherrypick``, ``git rebase``, etc.), git finds the relevant snapshots
+(e.g. ``git cherry-pick``, ``git rebase``, etc.), git finds the relevant snapshots
 and calculates the deltas on the fly.
 
 2) "History is only for humans"

--- a/html/_sources/git/git_workflows.rst.txt
+++ b/html/_sources/git/git_workflows.rst.txt
@@ -60,7 +60,7 @@ original post, ["A successful Git branching
 model,"](http://nvie.com/posts/a-successful-git-branching-model/) is well worth
 a read.
 
-At the backbone of the project are the **maste**r and the **develop** branches.
+At the backbone of the project are the **master** and the **develop** branches.
 Supporting branches are all **features**, **releases**, and **hotfixes**. The
 figure and table below summarize how all of these branches work together.
 

--- a/html/_sources/git/git_workflows.rst.txt
+++ b/html/_sources/git/git_workflows.rst.txt
@@ -13,7 +13,7 @@ Summary:
 Most of this section comes from the `Atlassian workflow overview
 <https://www.atlassian.com/git/tutorials/comparing-workflows/>`_, including the
 figures (under the `CC-au license
-<https://creativecommons.org/licenses/by/2.5/au/)>`_. I like this presentation
+<https://creativecommons.org/licenses/by/2.5/au/>`_). I like this presentation
 of git workflows, because it starts from the SVN-like model that many are
 comfortable with, and adds one new concept for each successive workflow. This
 way, one can partition their understanding and choose the level at which they

--- a/html/_sources/git/resources.rst.txt
+++ b/html/_sources/git/resources.rst.txt
@@ -6,43 +6,43 @@ Big list o' resources -- links to external sites
 general reference, tutorials, cheatsheets
 ==========================================
 
-pro git book (https://git-scm.com/book/en/v2)
+`pro git book <https://git-scm.com/book/en/v2>`_
 
-| atlassian git and related tools tutorials (https://www.atlassian.com/git/tutorials)
-| github guides (https://guides.github.com)
-| github list of external tutorials (https://help.github.com/articles/good-resources-for-learning-git-and-github/)
+| `atlassian git and related tools tutorials <https://www.atlassian.com/git/tutorials>`_
+| `github guides <https://guides.github.com>`_
+| `github list of external tutorials <https://help.github.com/articles/good-resources-for-learning-git-and-github/>`_
 
-| git quick/basic reference (http://gitref.org/index.html)
-| github git cheatsheet (https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf)
-| atlassian git cheatsheet (https://www.atlassian.com/dms/wac/images/landing/git/atlassian_git_cheatsheet.pdf)
+| `git quick/basic reference <http://gitref.org/index.html>`_
+| `github git cheatsheet <https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf>`_
+| `atlassian git cheatsheet <https://www.atlassian.com/dms/wac/images/landing/git/atlassian_git_cheatsheet.pdf>`_
 
 branching, forking, remotes
 ============================
-| learn git branching - in-depth tutorial (http://pcottle.github.io/learnGitBranching)
-| the first page of the reference chapter on git branching (https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell)
-| syncing (remote, fetch, pull, push) overview (https://www.atlassian.com/git/tutorials/syncing)
+| `learn git branching - in-depth tutorial <http://pcottle.github.io/learnGitBranching>`_
+| `the first page of the reference chapter on git branching <https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell>`_
+| `syncing (remote, fetch, pull, push) overview <https://www.atlassian.com/git/tutorials/syncing>`_
 | https://help.github.com/articles/fork-a-repo/
 | https://help.github.com/articles/syncing-a-fork/
 
 best practices
 ===============
-| 10 simple rules paper (http://biorxiv.org/content/early/2016/05/13/048744)
-| Commit Often, Perfect Later, Publish Once: Git Best Practices (http://sethrobertson.github.io/GitBestPractices/)
-| A Quick Introduction to Version Control with Git and Github (http://dx.doi.org/10.1371/journal.pcbi.1004668)
-| No Foxtrot Merges Allowed (http://bit-booster.blogspot.ca/2016/02/no-foxtrots-allowed.html)
-| Sympy syncing guidance (prefer merge over rebase) (https://github.com/sympy/sympy/wiki/Development-workflow#synchronization-with-master-sympy-sympy)
-| Getting Solid at Git rebase vs. merge (https://medium.com/@porteneuve/getting-solid-at-git-rebase-vs-merge-4fa1a48c53aa)
+| `10 simple rules paper <http://biorxiv.org/content/early/2016/05/13/048744>`_
+| `Commit Often, Perfect Later, Publish Once: Git Best Practices <http://sethrobertson.github.io/GitBestPractices/>`_
+| `A Quick Introduction to Version Control with Git and Github <http://dx.doi.org/10.1371/journal.pcbi.1004668>`_
+| `No Foxtrot Merges Allowed <http://bit-booster.blogspot.ca/2016/02/no-foxtrots-allowed.html>`_
+| `Sympy syncing guidance <prefer merge over rebase>`_ (https://github.com/sympy/sympy/wiki/Development-workflow#synchronization-with-master-sympy-sympy)
+| `Getting Solid at Git rebase vs. merge <https://medium.com/@porteneuve/getting-solid-at-git-rebase-vs-merge-4fa1a48c53aa>`_
 
 workflows and history cleaning for PRs
 =======================================
-| workflows overview  (https://www.atlassian.com/git/tutorials/comparing-workflows)
-| the original gitflow  (http://nvie.com/posts/a-successful-git-branching-model/)
-| gitflow best practices and variations discussion  (http://stackoverflow.com/questions/24582319/branching-and-merging-best-practices-in-git)
-| git workflow guide with examples for pros (simple models)  (https://www.toptal.com/git/git-workflows-for-pros-a-good-git-guide)
-| git workflows that work  (http://blog.endpoint.com/2014/05/git-workflows-that-work.html)
+| `workflows overview  <https://www.atlassian.com/git/tutorials/comparing-workflows>`_
+| `the original gitflow  <http://nvie.com/posts/a-successful-git-branching-model/>`_
+| `gitflow best practices and variations discussion  <http://stackoverflow.com/questions/24582319/branching-and-merging-best-practices-in-git>`_
+| `git workflow guide with examples for pros <simple models>`_  (https://www.toptal.com/git/git-workflows-for-pros-a-good-git-guide)
+| `git workflows that work  <http://blog.endpoint.com/2014/05/git-workflows-that-work.html>`_
 
-| getting solid at git rebase vs. merge (https://medium.com/@porteneuve/getting-solid-at-git-rebase-vs-merge-4fa1a48c53aa#.wozxfe8am)
-| git ways of rewriting history (https://robots.thoughtbot.com/git-interactive-rebase-squash-amend-rewriting-history)
+| `getting solid at git rebase vs. merge <https://medium.com/@porteneuve/getting-solid-at-git-rebase-vs-merge-4fa1a48c53aa#.wozxfe8am>`_
+| `git ways of rewriting history <https://robots.thoughtbot.com/git-interactive-rebase-squash-amend-rewriting-history>`_
 
 If you want to experiment with the Gitflow model, This script
 (`gitflow_history.sh </uploads/3ffd72450352f16d96ec6d4eeeff6a20/gitflow_history.sh>`_)
@@ -51,5 +51,5 @@ empty directory.
 
 miscellaneous non-git resources
 ===============================
-| make code citable (https://guides.github.com/activities/citable-codehttps://guides.github.com/activities/citable-code/)
-| semantic versioning (http://semver.org/)
+| `make code citable <https://guides.github.com/activities/citable-codehttps://guides.github.com/activities/citable-code/>`_
+| `semantic versioning <http://semver.org/>`_

--- a/html/_sources/git/resources.rst.txt
+++ b/html/_sources/git/resources.rst.txt
@@ -45,7 +45,7 @@ workflows and history cleaning for PRs
 | git ways of rewriting history (https://robots.thoughtbot.com/git-interactive-rebase-squash-amend-rewriting-history)
 
 If you want to experiment with the Gitflow model, This script
-([gitflow_history.sh](/uploads/3ffd72450352f16d96ec6d4eeeff6a20/gitflow_history.sh))
+(`gitflow_history.sh </uploads/3ffd72450352f16d96ec6d4eeeff6a20/gitflow_history.sh>`_)
 will generate the history shown in the Gitflow figure above; just execute in an
 empty directory.
 

--- a/html/_sources/git/resources.rst.txt
+++ b/html/_sources/git/resources.rst.txt
@@ -51,5 +51,5 @@ empty directory.
 
 miscellaneous non-git resources
 ===============================
-| `make code citable <https://guides.github.com/activities/citable-codehttps://guides.github.com/activities/citable-code/>`_
+| `make code citable <https://guides.github.com/activities/citable-code/>`_
 | `semantic versioning <http://semver.org/>`_


### PR DESCRIPTION
Both of them do copy, it's just that rebase also moves the branch head
making the previous commits slightly less accessible. Also it's git
cherry-pick with a hyphen.
